### PR TITLE
fix: handle flag name/shorthand overlap in non-posix mode

### DIFF
--- a/carapace-pflag_test.go
+++ b/carapace-pflag_test.go
@@ -162,3 +162,43 @@ func TestNargs(t *testing.T) {
 	}
 
 }
+
+func TestShorthandNameOverlap(t *testing.T) {
+	f := NewFlagSet("shorthandNameOverlap", ContinueOnError)
+	f.StringN("overlapping", "o", "", "overlapping flag")
+
+	args := []string{
+		"-overlapping", "value",
+	}
+	want := []string{
+		"overlapping", "value",
+	}
+	got := []string{}
+	store := func(flag *Flag, value string) error {
+		got = append(got, flag.Name)
+		if len(value) > 0 {
+			got = append(got, value)
+		}
+		return nil
+	}
+	if err := f.ParseAll(args, store); err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("f.TestShorthandNameOverlap() fail to restore the args")
+		t.Errorf("Got:  %v", got)
+		t.Errorf("Want: %v", want)
+	}
+
+	// ensure args are correctly parsed
+	f.Parse(args)
+	got2, err := f.GetString("overlapping")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	want2 := "value"
+	if got2 != want2 {
+		t.Errorf("Got:  %v", got2)
+		t.Errorf("Want: %v", want2)
+	}
+}

--- a/flag.go
+++ b/flag.go
@@ -1214,7 +1214,7 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 		// '-f=arg'
 		value = strings.SplitN(shorthands, string(flag.OptargDelimiter), 2)[1]
 		outShorts = ""
-	} else if flag.NoOptDefVal != "" {
+	} else if flag.NoOptDefVal != "" && (f.IsPosix() || shorthands == flag.Shorthand) {
 		// '-f' (arg was optional)
 		value = flag.NoOptDefVal
 	} else if len(shorthands) > 1 && f.IsPosix() {


### PR DESCRIPTION
In non-posix mode, when a flag name (like "overlapping") starts with a
shorthand character (like "o"), the parser incorrectly treated the full
name as the shorthand with a missing argument. This change adds a check
to only use NoOptDefVal for shorthand-style arguments (not longhand-like
arguments that happen to start with a shorthand character).

Assisted-by: Crush:minimax-m2.7

related https://github.com/carapace-sh/carapace/issues/1226